### PR TITLE
Refactor to unist-util-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # gatsby-remark-classes
+
 Automatically add class attributes to markdown elements.
 
 This is a plugin for [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/?=gatsby-transformer-remark).
 
 ## Install
+
 ```
 npm install --save gatsby-remark-classes
 ```
 
 ## Configure
+
 In your `gatsby-config.js`:
 
 ```js
@@ -20,9 +23,9 @@ In your `gatsby-config.js`:
         resolve: `gatsby-remark-classes`,
         options: {
           classMap: {
-            h1: 'title',
-            h2: 'subtitle',
-            paragraph: 'para'
+            "heading[depth=1]": "title-new",
+            "heading[depth=2]": "subtitle",
+            paragraph: "para",
           }
         }
       }
@@ -35,9 +38,11 @@ The rules above applied to the following markdown
 
 ```markdown
 # Main heading
+
 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eum, odio.
 
 ## Sub header
+
 Lorem ipsum dolor sit amet, consectetur adipisicing.
 ```
 
@@ -45,14 +50,17 @@ Will result in this HTML output:
 
 ```html
 <h1 class="title">Main heading</h1>
-<p class="para">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eum, odio.</p>
+<p class="para">
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eum, odio.
+</p>
 
 <h2 class="subtitle">Sub header</h2>
 <p class="para">Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
 ```
 
 ## The classMap
-Right now you can add styles for **heading** elements (h1 - h6), **paragraphs** and **tables**. 
+
+For supported selectors please have a look at the [Support section of unist-util-select](https://github.com/syntax-tree/unist-util-select#support)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Will result in this HTML output:
 
 ## The classMap
 
-For supported selectors please have a look at the [Support section of unist-util-select](https://github.com/syntax-tree/unist-util-select#support)
+For supported selectors please please consult [syntax-tree/mdast](https://github.com/syntax-tree/mdast#nodes) for the node list and have a look at the [Support section of unist-util-select](https://github.com/syntax-tree/unist-util-select#support)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ For supported selectors please have a look at the [Support section of unist-util
 Applying custom styles is also possible by just wrapping your converted markdown in a parent element and write the styles for that. This will however not work if you use atomic css in your project or a framework like Semantic UI or Tailwind CSS.
 
 With this project you define which classes get assigned to which element.
+
+## Upgrade guide
+
+When upgrading from version 0.x.x to 1.x.x, you will have to update the selectors in your `gatsby-config.js` file.
+
+Some common selectors:
+
+- `h1` is now `heading[depth=1]`
+- `h2` is now `heading[depth=2]`
+- `paragraph` is still `paragraph`
+
+Additionally you have now the chance to target child elements `code > pre` or even adjacent elements `paragraph + paragraph`. As stated above, please consult [syntax-tree/unist-util-select](https://github.com/syntax-tree/unist-util-select#support) for the complete list.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In your `gatsby-config.js`:
         resolve: `gatsby-remark-classes`,
         options: {
           classMap: {
-            "heading[depth=1]": "title-new",
+            "heading[depth=1]": "title",
             "heading[depth=2]": "subtitle",
             paragraph: "para",
           }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Some common selectors:
 
 - `h1` is now `heading[depth=1]`
 - `h2` is now `heading[depth=2]`
+- `ul` is now `list[ordered=false]`
+- `ol` is now `list[ordered=true]`
+- `li` is now `listItem`
 - `paragraph` is still `paragraph`
 
-Additionally you have now the chance to target child elements `code > pre` or even adjacent elements `paragraph + paragraph`. As stated above, please consult [syntax-tree/unist-util-select](https://github.com/syntax-tree/unist-util-select#support) for the complete list.
+Additionally you have now the chance to target child elements `code > pre` or even adjacent elements `paragraph + paragraph`. As stated above, please consult [syntax-tree/mdast](https://github.com/syntax-tree/mdast#nodes) for the node list and [syntax-tree/unist-util-select](https://github.com/syntax-tree/unist-util-select#support) for pseudo selectors and syntax.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const visit = require('unist-util-visit');
+const { selectAll } = require('unist-util-select');
 
 const applyClassesToNode = (node, classes) => {
   node.data = node.data || {};
@@ -11,28 +11,11 @@ const applyClassesToNode = (node, classes) => {
 };
 
 module.exports = ({ markdownAST }, { classMap = {} }) => {
-  // @see: https://github.com/syntax-tree/mdast#nodes
-  visit(markdownAST, `heading`, (node) => {
-    const selector = `h${node.depth}`;
+  Object.keys(classMap).forEach((selector) => {
+    const nodes = selectAll(selector, markdownAST);
 
-    if (selector in classMap) {
+    nodes.forEach((node) => {
       node = applyClassesToNode(node, classMap[selector]);
-    }
-  });
-
-  visit(markdownAST, `table`, (node) => {
-    const selector = `table`;
-
-    if (selector in classMap) {
-      node = applyClassesToNode(node, classMap[selector]);
-    }
-  });
-
-  visit(markdownAST, `paragraph`, (node) => {
-    const selector = `paragraph`;
-
-    if (selector in classMap) {
-      node = applyClassesToNode(node, classMap[selector]);
-    }
+    });
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,53 @@
 {
   "name": "gatsby-remark-classes",
-  "version": "1.0.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "css-selector-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
+      "integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s="
+    },
+    "not": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
+      "integrity": "sha1-yWkcF0bFXc++VMvYvU/wQbwrUZ0="
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
     "unist-util-is": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
     },
-    "unist-util-visit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+    "unist-util-select": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-2.0.2.tgz",
+      "integrity": "sha512-Yv5Z5ShMxv7Z9Dw175tKvOiRVXV4FrMHG778DSD9Z0jALgb3wAx9DoeInr3200QlYp71rYUXzzJdCb76xKdrCw==",
       "requires": {
-        "unist-util-visit-parents": "^2.0.0"
+        "css-selector-parser": "^1.1.0",
+        "not": "^0.1.0",
+        "nth-check": "^1.0.1",
+        "unist-util-is": "^3.0.0",
+        "zwitch": "^1.0.3"
       }
     },
-    "unist-util-visit-parents": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
-      "requires": {
-        "unist-util-is": "^2.1.2"
-      }
+    "zwitch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.4.tgz",
+      "integrity": "sha512-YO803/X+13GNaZB7fVopjvHH0uWQKgJkgKnU1YCjxShjKGVuN9PPHHW8g+uFDpkHpSTNi3rCMKMewIcbC1BAYg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Chris Greindl <chris.greindl@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "unist-util-visit": "^1.4.0"
+    "unist-util-select": "^2.0.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-classes",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Automatically add class attributes to rendered markdown elements",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Make use of `unist-util-select` for dynamic selectors. No more manual adding.